### PR TITLE
Point the URL to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ kubectl proxy --www=.
 Starting to serve on 127.0.0.1:8001
 ```
 
-Open the following URL <http://127.0.0.1:8001/static>.
+Open the following URL <http://localhost:8001/static>.
 
 The page will guide through creating the appropriate credentials to connect to Google Spreadsheet.
 


### PR DESCRIPTION
Google doesn't authorize URLs with 127.0.0.1.
Corrected the README file to use localhost instead. 

Reference: https://stackoverflow.com/a/48456350/9403545